### PR TITLE
Fix build with latest GHC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-dist/
+dist*
 cabal-dev

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages: .
+
+-- https://github.com/GaloisInc/sqlite/pull/14
+source-repository-package
+    type: git
+    location: https://github.com/GaloisInc/sqlite
+    tag: e93ee84000c1d1eedbc23036c4a20ffd07e3145f


### PR DESCRIPTION
There's a lot more that _could_ be done to modernise the package, but this is enough to get it running with GHC 9.10. I haven't tested extensively, but `cabal run thimk -- werds -d /usr/share/dict/cracklib-small -n 10` works.